### PR TITLE
Corrected name: TD = Tim Disney; Restored names: AWB = Allen Wirfs-Brock...

### DIFF
--- a/profiles.json
+++ b/profiles.json
@@ -101,7 +101,7 @@
   },
   {
     "id": "TD",
-    "displayName": "Brian Terlson"
+    "displayName": "Tim Disney"
   },
   {
     "id": "BT",
@@ -122,5 +122,13 @@
   {
     "id": "NC",
     "displayName": "Nebojsa Ciric"
+  },
+  {
+    "id": "AWB",
+    "displayName": "Allen Wirfs-Brock"
+  },
+  {
+    "id": "DS",
+    "displayName": "Dmitry Soshnikov"
   }
 ]


### PR DESCRIPTION
..., DS = Dmitry Soshnikov

Signed-off-by: Rick Waldron waldron.rick@gmail.com
