### PR TITLE
feat: Add RSS feed

### DIFF
--- a/server.js
+++ b/server.js
@@ -61,7 +61,17 @@ app.get('/about', function (req, res, next) {
     });
   }).done(null, next);
 })
-
+app.get('/rss', function (req, res, next) {
+  var page = 0;
+  db.page(page)
+      .done(function (topics) {
+        if (topics.length === 0) return next();
+        res.set('Content-Type', 'application/rss+xml');
+        res.render('rss', {
+          topics: topics
+        });
+      }, next);
+});
 app.get('/:page', function (req, res, next) {
   if (!/^\d+$/.test(req.params.page)) return next();
 

--- a/test/index.js
+++ b/test/index.js
@@ -61,3 +61,5 @@ path('/pipermail/es-discuss/2013-June/930958.html', 404);
 
 path('/notes', 200);
 path('/notes/2013-03-14', 200);
+
+path('/rss', 200);

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -5,6 +5,7 @@ html
     block title
       title ES Discuss
     meta(name="viewport", content="width=device-width, initial-scale=1.0")
+    link(rel="alternate" type="application/rss+xml" href="/rss")
     block head
     link(href='https://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.min.css', rel='stylesheet')
     link(href='/style.css', rel='stylesheet')

--- a/views/rss.jade
+++ b/views/rss.jade
@@ -1,0 +1,17 @@
+doctype xml
+rss(version="2.0", xmlns:atom="http://www.w3.org/2005/Atom")
+   channel
+      title= "ES Discuss"
+      link= "http://esdiscuss.org/rss"
+      description= "ES Discuss"
+      atom:link(href="http://esdiscuss.org/rss", rel="self", type="application/rss+xml")
+      for topic in topics
+         item
+            title= topic.subject
+            atom:author
+                name #{topic.first.name || topic.first.email.replace(/@/g, ' at ')}
+            // RFC-822 format
+            pubDate= topic.end.format('ddd, DD MMM YYYY HH:mm:ss ZZ')
+            atom:link(rel="self", href="http://esdiscuss.org/topic/#{ topic._id }")
+            link http://esdiscuss.org/topic/#{ topic._id }
+            guid http://esdiscuss.org/topic/#{ topic._id }


### PR DESCRIPTION
Would be nice to have a RSS feed on esdiscuss.org.
This pull request added `/rss` page that provide RSS feed of topics.

![2015-06-28_01-47-55](https://cloud.githubusercontent.com/assets/19714/8393004/bdee2110-1d37-11e5-92c5-d99bcc8b0241.jpg)

I hope you don't mind - this is purely driven by selfish needs. :)