### PR TITLE
Update grtp.co widget API from v1 to v2

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -48,7 +48,7 @@ html
     #footer-wrapper
       footer
         .right
-          script(data-gratipay-username="esdiscuss", src="https://grtp.co/v1.js")
+          script(data-gratipay-teamslug="esdiscuss", src="https://grtp.co/v2.js" async)
         p
           | Developed by&nbsp;
           a.jepso(href='http://www.forbeslindesay.co.uk') @ForbesLindesay


### PR DESCRIPTION
With API v1, the URL of the link to gratipay was set to https://gratipay.com/undefined/.
This patch fixes the URL to https://gratipay.com/esdiscuss/.

ref. https://github.com/gratipay/grtp.co/blob/8bf548e745c4de93893cea44df4b03a03f6591fd/README.md#standard-widgets