### PR TITLE
don't replace free-floating potential initials with member names

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -116,7 +116,7 @@ function processNote(content, date, isNotMeetingNotes, month) {
   content = md.render(content);
 
   content = content.replace(/\[\[\[PersonName:((?:[\w\'\-]|&#39;)+\s(?:[\w\'\-]|&#39;)+)\]\]\]/g, function (_, name) {
-    name.replace(/&#39;/g, "'")
+    name = name.replace(/&#39;/g, "'")
     for (var i = 0; i < profiles.length; i++) {
       if (profiles[i].id === name || profiles[i].displayName === name) {
         return profiles[i].displayName;

--- a/lib/process.js
+++ b/lib/process.js
@@ -115,15 +115,14 @@ function processNote(content, date, isNotMeetingNotes, month) {
 
   content = md.render(content);
 
-  content = content.replace(/\[\[\[PersonName:((?:[\w\'\-]|&#39;)+\s(?:[\w\'\-]|&#39;)+)\]\]\]|\b([A-Z]{2,3})\b/g, function (_, name, id) {
-    id = id || name;
-    id = id.replace(/&#39;/g, "'")
+  content = content.replace(/\[\[\[PersonName:((?:[\w\'\-]|&#39;)+\s(?:[\w\'\-]|&#39;)+)\]\]\]/g, function (_, name) {
+    name.replace(/&#39;/g, "'")
     for (var i = 0; i < profiles.length; i++) {
-      if (profiles[i].id === id || profiles[i].displayName === id) {
+      if (profiles[i].id === name || profiles[i].displayName === name) {
         return profiles[i].displayName;
       }
     }
-    return id;
+    return name;
   });
   content = redirectLinks(shortenLinks(content));
   content = content.replace(/(<a[^<>]*) href=\"[a-z]+\-([0-9]{1,2})\.md((?:\#[^\"]*))\"([^<>]*>)/gi, (_, start, day, fragment, end) => {


### PR DESCRIPTION
See issue https://github.com/esdiscuss/esdiscuss.org/issues/229

"JS" and "API" were being replaced with full member names anywhere they appeared.