### PR TITLE
Autocomplete dropdown visible on mobile

### DIFF
--- a/less/bootstrap/navbar.less
+++ b/less/bootstrap/navbar.less
@@ -57,10 +57,6 @@
   .clearfix();
   -webkit-overflow-scrolling: touch;
 
-  &.in {
-    overflow-y: auto;
-  }
-
   @media (min-width: @grid-float-breakpoint) {
     width: auto;
     border-top: 0;


### PR DESCRIPTION
Hi I'm a frequent visitor to esdiscuss, and I'd like to fix a bug.  

The autocomplete is obscured in the mobile view by `overflow-y: auto;`.  The dropdown is still accessible by scrolling, but the scroll bar is invisible on some phones, making the autocomplete appear broken.

The proposed solution removes the `overflow-y:auto;` on mobile, displaying the dropdown below the navbar. 