### PR TITLE
Add search page

### DIFF
--- a/server.js
+++ b/server.js
@@ -130,6 +130,10 @@ app.get('/topic/:id', function (req, res, next) {
     }, next);
 });
 
+app.get('/search', function(req, res, next) {
+  res.render('search');
+});
+
 app.get('/search-result/:id', function (req, res, next) {
   return db.getTopicFromMessageID(req.params.id).then(function (subjectID) {
     if (!subjectID) return next();

--- a/views/search.pug
+++ b/views/search.pug
@@ -1,0 +1,37 @@
+extends layout
+
+block content
+  #aaa-input-container.aa-input-container
+    input#aaa-search-input.aa-input-search(
+      type="search"
+      placeholder="Search for messages..."
+      name="search"
+      autocomplete="off"
+    )
+
+block scripts
+  script.
+    (function () {
+      var client = algoliasearch("#{process.env.ALGOLIA_APPLICATION_ID}", "#{process.env.ALGOLIA_SEARCH_KEY}");
+      var index = client.initIndex('messages');
+      //initialize autocomplete on search input (ID selector must match)
+      autocomplete('#aaa-search-input',
+        { hint: true }, {
+        source: autocomplete.sources.hits(index, {hitsPerPage: 5, distinct: true}),
+        //value to be displayed in input control after user's suggestion selection
+        displayKey: 'subject',
+        //hash of templates used when rendering dataset
+        templates: {
+          //'suggestion' templating function used to render a single suggestion
+          suggestion: function(suggestion) {
+            return '<span>' +
+              suggestion._highlightResult.subject.value + '</span>';
+          },
+          // Algolia_logo_bg-white.svg
+          footer: '<span>Search powered by <img height="20px" src="#{asset('/Algolia_logo_bg-white.svg')}"/></span>'
+        }
+      }).on('autocomplete:selected', function (e, selectedItem, dataset) {
+        location.assign('/search-result/' + selectedItem.objectID);
+        console.dir(selectedItem);
+      });
+    }());


### PR DESCRIPTION
- [ ] `/search` route
- [ ] Add first version with autocomplete
- [ ] Improve design
- [ ] Add matched body text
- [ ] Search through notes too (or is this done already?)
- [ ] Add navigation item to go to page
- [ ] Handle search parameters so that non-direct-match searches from search box go to the results page

Closes #42 